### PR TITLE
added linguist override to mark language as XPages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
+# XPages love on GitHub
+*.xsp linguist-language=XPages
+*.xsp-config linguist-language=XPages
+*.xsp.metadata linguist-language=XPages
+*.form linguist-language=XPages
+*.view linguist-language=XPages
 
 # Dora Start
 


### PR DESCRIPTION
I wish the .xsp extension had been unique, but apparently kept lang=XPages from happening how we'd expect. In any case, the override in .gitattributes shows to the world that you write XPages apps without a care.
